### PR TITLE
Intersection calculator: Unzip vs JSON

### DIFF
--- a/go-corona-app/screens/crosscheck/intersection/UploadData.js
+++ b/go-corona-app/screens/crosscheck/intersection/UploadData.js
@@ -35,7 +35,7 @@ export default function UploadDataScreen() {
         }
 
         console.log(inputFileResult)
-        
+
         if (inputFileResult.type === "success") {
             setUploadedFileMeta(inputFileResult)
 
@@ -91,7 +91,7 @@ export default function UploadDataScreen() {
                     </View>
                     <Separator />
                     <View style={styles.sectionContainer}>
-                        <Text style={styles.title}>Upload the Google Takeout Zip file</Text>
+                        <Text style={styles.title}>Upload the Google Takeout location data</Text>
                         <View style={styles.helpLinks}>
                             <CustomButton
                                 Icon={uploadedFileMeta ? TickIcon : UploadIcon}
@@ -101,6 +101,7 @@ export default function UploadDataScreen() {
                                 onPress={handleUploadFilePress}
                             />
                         </View>
+                        <Text style={styles.uploadTypeMessage}>{Platform.OS === "ios" ? "Please select the takeout-xx.zip" : "Please select Location History.json"}</Text>
                     </View>
                 </View>
             </View>
@@ -134,5 +135,7 @@ const styles = StyleSheet.create({
     uploadedFileMessage: {
         flexWrap: "wrap",
         textAlign: "center"
+    },
+    uploadTypeMessage: {
     }
 });

--- a/go-corona-app/screens/crosscheck/intersection/UploadData.js
+++ b/go-corona-app/screens/crosscheck/intersection/UploadData.js
@@ -1,8 +1,9 @@
 import { Ionicons } from '@expo/vector-icons';
 import React, { useState } from 'react';
-import { StyleSheet, Text, View, Image, ScrollView } from 'react-native';
+import { StyleSheet, Text, View, Image, ScrollView, Platform } from 'react-native';
 import * as DocumentPicker from 'expo-document-picker';
 import * as WebBrowser from 'expo-web-browser';
+import * as FileSystem from 'expo-file-system';
 
 import ProgressBarContainer from '../../../components/ProgressBar';
 import CustomButton from '../../../components/button/index'
@@ -18,15 +19,38 @@ export default function UploadDataScreen() {
     const [uploadedFileMeta, setUploadedFileMeta] = useState(null)
     const [uploadInProgress, setUploadInProgress] = useState(false)
 
+    const pickZipFile = async () => await DocumentPicker.getDocumentAsync({ type: 'application/zip' })
+
+    const pickJsonFile = async () => await DocumentPicker.getDocumentAsync({ type: '*/*' })
+
     const handleUploadFilePress = async () => {
         setUploadInProgress(true)
 
-        const result = await DocumentPicker.getDocumentAsync({ type: 'application/zip' })
-        if (result.type === "success") {
-            setUploadedFileMeta(result)
+        let inputFileResult = null
 
-            const unzippedFiles = await unzipArchive(result.uri)
-            const json_file = await getLocationHistoryFile(unzippedFiles)
+        if (Platform.OS === "ios") {
+            inputFileResult = await pickZipFile()
+        } else {
+            inputFileResult = await pickJsonFile()
+        }
+
+        console.log(inputFileResult)
+        
+        if (inputFileResult.type === "success") {
+            setUploadedFileMeta(inputFileResult)
+
+            let json_file = null
+
+            if (Platform.OS === "ios") {
+                const unzippedFiles = await unzipArchive(inputFileResult.uri)
+                json_file = await getLocationHistoryFile(unzippedFiles)
+            } else {
+                const fileUri = `${FileSystem.documentDirectory}${inputFileResult.name}`
+                const copyAsync = await FileSystem.copyAsync({ from: inputFileResult.uri, to: fileUri })
+
+                const read = await FileSystem.readAsStringAsync(fileUri)
+                json_file = JSON.parse(read)
+            }
 
             if (json_file) {
                 const filteredTimestamps = await filterJsonData(json_file)
@@ -39,7 +63,6 @@ export default function UploadDataScreen() {
             }
 
         }
-        console.log(result)
         setUploadInProgress(false)
     }
 


### PR DESCRIPTION
- Tried multiple approaches; could not fix the Android bug for "importing" a ZIP file (looks like there is something peculiar to Android and Binary files)

- Changed the solution a little to accept directly the History Location.json file in Android and iOS still supports accepting ZIP file

- We can evaluate this and make it consistent after testing